### PR TITLE
Fix MacOS JAVA_HOME

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -32,7 +32,11 @@ func run(c *cli.Context) error {
 
 	if javaHome == "" {
 		if _, err := os.Stat(path.Join(mlsqlHome, "jdk8")); !os.IsNotExist(err) {
-			javaHome = path.Join(mlsqlHome, "jdk8")
+		    if ( "darwin" == runtime.GOOS ) {
+		        javaHome = path.Join(mlsqlHome, "jdk8/Contents/Home")
+		    } else {
+			    javaHome = path.Join(mlsqlHome, "jdk8")
+			}
 		}
 	}
 


### PR DESCRIPTION
## 问题
不设置 JAVA_HOME 时，MacOS 上运行 byzer-all-in-one 的 byzer CLI 。 报错：
```text
 22/07/21 17:27:34  WARN JavaUtils: Attempt to delete using native Unix OS command failed for path = /private/var/folders/0q/8tc37ghn46j6mnmnqkj6j3w42x39hc/T/spark-70eb4f23-76b6-4ab5-b15c-37ec20c6664a. Falling back to Java IO way
java.io.IOException: Failed to delete: /private/var/folders/0q/8tc37ghn46j6mnmnqkj6j3w42x39hc/T/spark-70eb4f23-76b6-4ab5-b15c-37ec20c6664a
	at org.apache.spark.network.util.JavaUtils.deleteRecursivelyUsingUnixNative(JavaUtils.java:163)
	at org.apache.spark.network.util.JavaUtils.deleteRecursively(JavaUtils.java:110)
	at org.apache.spark.network.util.JavaUtils.deleteRecursively(JavaUtils.java:91)
```

**复现步骤**
1. 下载[All-in-one](https://download.byzer.org/byzer/2.3.1/byzer-lang-all-in-one-darwin-amd64-3.1.1-2.3.1.tar.gz) 并解压缩
2. 执行 `unset JAVA_HOME`
3. 进入解压后的 `all-in-one/bin` 目录，执行 `./byzer run ./hello.byzer`

若设置 JAVA_HOME ，执行不报错。这里, byzer CLI 使用了 系统 JAVA_HOME。 系统 `JAVA_HOME` 为 openjdk-8u332， 目录结构如下：
```
└── [Jul 20 11:20]  jdk1.8.0_332.jdk
    └── [Jul 20 11:06]  Contents
        ├── [Jul 20 11:20]  Home
        │   ├── [Apr 25 16:42]  ASSEMBLY_EXCEPTION
        │   ├── [Apr 25 16:42]  LICENSE
        │   ├── [Apr 25 16:42]  THIRD_PARTY_README
        │   ├── [Apr 25 16:42]  bin
        │   ├── [Apr 25 16:42]  demo
        │   ├── [Apr 25 16:42]  include
        │   ├── [Apr 25 16:42]  jre
        │   ├── [Apr 25 16:42]  lib
        │   ├── [Apr 25 16:42]  man
        │   ├── [Apr 25 16:42]  release
        │   ├── [Apr 25 16:42]  sample
        │   └── [Apr 25 16:42]  src.zip
        ├── [Apr 25 16:42]  Info.plist
        ├── [Apr 25 16:42]  MacOS
        │   └── [Apr 25 16:42]  libjli.dylib
        └── [Apr 25 16:42]  _CodeSignature
            └── [Apr 25 16:42]  CodeResources
```

可以看到，系统JAVA_HOME 比 all-in-one 自带 JDK 多了 `Content/MacOS/libjli.dylib`，Google 后发现该文件与 JNI 有关。 [OpenJDK - macoS](https://github.com/openjdk/jdk/blob/master/src/java.base/macosx/native/libjli/java_md_macosx.m`) 
[SO 帖子](https://stackoverflow.com/questions/51102735/what-is-the-java-libjli-library-for)

**总结** ：JDK 缺乏 `libjli.dylib`  (JNI) 时，无法调用操作系统库函数删除文件。

## 尝试解决
替换 All-in-one 自带 jdk8 为目录更完整的版本，并修改 byzer cli， 适配 MacOS JAVA_HOME 目录结构。 
再次执行上面的复现步骤，不再报错。
